### PR TITLE
Fix: Could not set the exchange for AMQP

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class AmqpAdapter extends Adapter {
       this.options.frameMax = this.options.frameMax || 0;
       this.options.heartbeat = this.options.heartbeat || 0;
       this.options.vhost = this.options.vhost || '/';
-      this.options.exchange = this.options.exchangeOptions || 'amq.topic';
+      this.options.exchange = this.options.exchange || 'amq.topic';
       this.options.exchangeOptions = this.options.exchangeOptions || {};
       this.options.queue = this.options.queue || '';
       this.options.queueOptions = this.options.queueOptions || {};


### PR DESCRIPTION
When using the asyncapi/generator to connect to RabbitMQ I could not set the exchange for the subscription.  I had a look at the code and notice that the exchange option was not being used by hermes-amqp instead it was trying to use `exchangeOptions` to set the exchange name to connect to when it should have been the `exchange` option to match the documentation.  I tested it with asyncapi/generator and RabbitMQ 3.9.10.  This allowed me to specify the exchange.